### PR TITLE
fixing deprecated gridUnit and gridDistance

### DIFF
--- a/system.json
+++ b/system.json
@@ -97,6 +97,6 @@
   "initiative": "1d10",
   "manifest": "https://github.com/DrOgres/tftloop/releases/latest/download/system.json",
   "download": "https://github.com/DrOgres/tftloop/releases/download/3.3.1/system.zip",
-  "gridDistance": 1,
-  "gridUnits": "meter"
+  "grid.distance": 1,
+  "grid.units": "meter"
 }


### PR DESCRIPTION
updated the deprecated gridUnit and gridDistance to use grid.units and grid.distance respectively