### PR TITLE
dark/light mode fixes

### DIFF
--- a/less/config.less
+++ b/less/config.less
@@ -61,18 +61,11 @@
 }
 
 .dialog-content {
-    background: @background;
-    color: @black;
-    border: 1px solid @black;
-    border-radius: 5px;
-    padding: 5px;
-    margin: 5px;
-}
-
-option,
-optgroup{
     font-family: Avant, sans-serif;
-    background: @field-color;
+
+    .option, .optgroup {
+        font-family: Avant, sans-serif;
+    }
 }
 
 #client-settings nav.tabs {
@@ -107,8 +100,6 @@ button:hover {
     background-color: @background;
     background: @background;
 }
-
-
 
 a:hover {
     box-shadow: none;

--- a/less/sheet.less
+++ b/less/sheet.less
@@ -128,11 +128,8 @@
 }
 
 .window-content {
+
     .dialog-content {
-        background: url(img/chat_background.jpg);
-        padding: 5px;
-        box-shadow: 2px 2px @drop-shadow-color;
-        margin-bottom: 3px;
 
         .bug {
             background: url(img/loop_bug_sm.png);


### PR DESCRIPTION
Foundry’s default color setting doesn’t work properly in the system. Not only does the styling interact with the new Actor, Item, etc. dialog, but it also messes up the User Interface Configuration dialog itself. This PR fixes all those issues.

`.dialog-content` now allows Foundry’s styling to take over for colors until such a time that it is decided that Tales from the Loop should have a dedicated Dark/Light mode.
`.option` and `.optgroup`’s font-family override, now only override text in `dialog-content`, not all times they appear in the application, (e.g. Foundry’s configuration menus).
<img width="663" height="554" alt="image" src="https://github.com/user-attachments/assets/9f0785fa-705d-4015-a3a5-c118e881fd88" />
